### PR TITLE
Create fcroc.nl

### DIFF
--- a/lib/domains/nl/fcroc.nl
+++ b/lib/domains/nl/fcroc.nl
@@ -1,0 +1,1 @@
+Friesland College


### PR DESCRIPTION
Email domain for teachers of Friesland College (frieslandcollege.nl)