### PR TITLE
Adding Jesuit High School

### DIFF
--- a/lib/domains/net/jhs.txt
+++ b/lib/domains/net/jhs.txt
@@ -1,0 +1,1 @@
+Jesuit High School


### PR DESCRIPTION
Jesuit High School of Sacramento California, Provides LastNameFirstInitialGradYear@student.jhs.net
Example: Bill Gates graduates in 2016 gatesb16@student.jhs.net

School website is jesuithighschool.org, but the club page can be accessed via jhs.net

The high school is Jesuit High School of Sacramento California
This is the whois record, and the home website for Jesuit is Jesuithighschool.org

Domain Name: JHS.NET
Registry Domain ID: 5276248_DOMAIN_NET-VRSN
Registrar WHOIS Server: whois.networksolutions.com
Updated Date: 2015-01-28T23:28:49Z
Creation Date: 1997-05-06T04:00:00Z
Registrar Registration Expiration Date: 2016-05-07T04:00:00Z
Registrant Name: Jesuit High School
Registrant Organization: Jesuit High School
Registrant Street: 1200 Jacob lane
Registrant City: Carmichael
Registrant State/Province: CA
Registrant Postal Code: 95608
Registrant Country: US
Registrant Phone: +1.9164826060
